### PR TITLE
Change launch_tool to tool_launch in Launcher

### DIFF
--- a/install/Launcher
+++ b/install/Launcher
@@ -9,8 +9,8 @@
 # as published by the Free Software Foundation; version 3 with
 # attribution addendums as found in the LICENSE.txt
 
-require_relative 'tools/launch_tool'
-launch_tool do
+require_relative 'tools/tool_launch'
+tool_launch do
   require 'cosmos/tools/launcher/launcher'
   Cosmos::Launcher.run
 end


### PR DESCRIPTION
Since tools/launch_tool.rb was changed to tools/tool_launch.rb in 3.5.0, the corresponding change needed to be made in Launcher.